### PR TITLE
Add smelting recipes for raw ore blocks

### DIFF
--- a/data/simplanet/recipes/copper_block_blasting.json
+++ b/data/simplanet/recipes/copper_block_blasting.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:blasting",
+    "ingredient": {
+        "item": "minecraft:raw_copper_block"
+    },
+    "result": "minecraft:copper_block",
+    "experience": 6.3,
+    "cookingtime": 900
+}

--- a/data/simplanet/recipes/copper_block_smelting.json
+++ b/data/simplanet/recipes/copper_block_smelting.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:smelting",
+    "ingredient": {
+        "item": "minecraft:raw_copper_block"
+    },
+    "result": "minecraft:copper_block",
+    "experience": 6.3,
+    "cookingtime": 1800
+}

--- a/data/simplanet/recipes/gold_block_blasting.json
+++ b/data/simplanet/recipes/gold_block_blasting.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:blasting",
+    "ingredient": {
+        "item": "minecraft:raw_gold_block"
+    },
+    "result": "minecraft:gold_block",
+    "experience": 9,
+    "cookingtime": 900
+}

--- a/data/simplanet/recipes/gold_block_smelting.json
+++ b/data/simplanet/recipes/gold_block_smelting.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:smelting",
+    "ingredient": {
+        "item": "minecraft:raw_gold_block"
+    },
+    "result": "minecraft:gold_block",
+    "experience": 9,
+    "cookingtime": 1800
+}

--- a/data/simplanet/recipes/iron_block_blasting.json
+++ b/data/simplanet/recipes/iron_block_blasting.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:blasting",
+    "ingredient": {
+        "item": "minecraft:raw_iron_block"
+    },
+    "result": "minecraft:iron_block",
+    "experience": 6.3,
+    "cookingtime": 900
+}

--- a/data/simplanet/recipes/iron_block_smelting.json
+++ b/data/simplanet/recipes/iron_block_smelting.json
@@ -1,0 +1,9 @@
+{
+    "type": "minecraft:smelting",
+    "ingredient": {
+        "item": "minecraft:raw_iron_block"
+    },
+    "result": "minecraft:iron_block",
+    "experience": 6.3,
+    "cookingtime": 1800
+}


### PR DESCRIPTION
This adds recipes for smelting raw copper/iron/gold blocks into their corresponding blocks.  Smelting times and experience rates are nine times those of individual ingots, though there is an argument to be made for making the smelting times only eight times normal to make the recipe consume coal in a one-to-one ratio.