### PR TITLE
Add amethyst block uncrafting recipe

### DIFF
--- a/data/simplanet/recipes/amethyst_shard.json
+++ b/data/simplanet/recipes/amethyst_shard.json
@@ -1,0 +1,12 @@
+{
+    "type": "minecraft:crafting_shapeless",
+    "ingredients": [
+        {
+            "item": "minecraft:amethyst_block"
+        }
+    ],
+    "result": {
+        "item": "minecraft:amethyst_shard",
+        "count": 4
+    }
+}


### PR DESCRIPTION
This adds a recipe for turning amethyst blocks back into shards, similar to the one we added for nether quartz.